### PR TITLE
[iOS] Improve stopCamera

### DIFF
--- a/src/ios/CameraPreview.swift
+++ b/src/ios/CameraPreview.swift
@@ -133,37 +133,36 @@ class CameraPreview: CDVPlugin, TakePictureDelegate, FocusDelegate {
             cameraRenderController.removeFromParentViewController()
             cameraRenderController = nil
         }
-
         
-        guard self.sessionManager != nil else {
-            print("--> Camera not started")
-            let pluginResult = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: "Camera not started")
-            self.commandDelegate.send(pluginResult, callbackId: command.callbackId)
-            return
-        }
-        
-        if let inputs = self.sessionManager.session?.inputs as? [AVCaptureInput] {
-            for input in inputs {
-                self.sessionManager.session?.removeInput(input)
+        commandDelegate.run(inBackground: {() -> Void in
+            guard self.sessionManager != nil else {
+                print("--> Camera not started")
+                let pluginResult = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: "Camera not started")
+                self.commandDelegate.send(pluginResult, callbackId: command.callbackId)
+                return
             }
-        }
-        
-        
-        if let outputs = self.sessionManager.session?.outputs as? [AVCaptureOutput] {
-            for output in outputs {
-                self.sessionManager.session?.removeOutput(output)
+            
+            if let inputs = self.sessionManager.session?.inputs as? [AVCaptureInput] {
+                for input in inputs {
+                    self.sessionManager.session?.removeInput(input)
+                }
             }
-        }
-        
-        self.sessionManager.session?.stopRunning()
-        
-        if self.sessionManager != nil {
-            self.sessionManager.delegate = nil;
-            self.sessionManager = nil;
-        }
-        
-        print("--> camera stopped")
-        self.commandDelegate.send(CDVPluginResult(status: CDVCommandStatus_OK), callbackId: command.callbackId)
+            
+            
+            if let outputs = self.sessionManager.session?.outputs as? [AVCaptureOutput] {
+                for output in outputs {
+                    self.sessionManager.session?.removeOutput(output)
+                }
+            }
+            
+            if self.sessionManager != nil {
+                self.sessionManager.delegate = nil;
+                self.sessionManager = nil;
+            }
+            
+            print("--> camera stopped")
+            self.commandDelegate.send(CDVPluginResult(status: CDVCommandStatus_OK), callbackId: command.callbackId)
+        })
     }
     
     @objc func hideCamera(_ command: CDVInvokedUrlCommand) {

--- a/src/ios/CameraPreview.swift
+++ b/src/ios/CameraPreview.swift
@@ -15,6 +15,7 @@ class CameraPreview: CDVPlugin, TakePictureDelegate, FocusDelegate {
     var withExifInfos = false
     var captureVideoOrientation: AVCaptureVideoOrientation?
     let dateFormatterForPhotoExif: DateFormatter = DateFormatter()
+    var startCameraInProgress = false;
     
     override func pluginInitialize() {
         // start as transparent
@@ -37,6 +38,8 @@ class CameraPreview: CDVPlugin, TakePictureDelegate, FocusDelegate {
     // 12 options.storageDirectory]
     @objc func startCamera(_ command: CDVInvokedUrlCommand) {
         print("--> startCamera")
+        
+        self.startCameraInProgress = true
         
         // Check if camera usage permission is granted in privacy settings. User only has to accept once.
         checkDeviceAuthorizationStatus({(_ granted: Bool) -> Void in
@@ -114,6 +117,8 @@ class CameraPreview: CDVPlugin, TakePictureDelegate, FocusDelegate {
                 self.sessionManager.delegate = self.cameraRenderController
                 self.sessionManager.setupSession(defaultCamera as? String, completion: {(_ started: Bool, _ error: String?) -> Void in
                     if started {
+                        print("--> camera started")
+                        self.startCameraInProgress = false
                         self.commandDelegate.send(CDVPluginResult(status: CDVCommandStatus_OK), callbackId: command.callbackId)
                     }
                 })
@@ -134,10 +139,24 @@ class CameraPreview: CDVPlugin, TakePictureDelegate, FocusDelegate {
             cameraRenderController = nil
         }
         
+        guard self.startCameraInProgress == false else {
+            print("--> startCamera in progress")
+            let pluginResult = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: "startCamera in progress")
+            self.commandDelegate.send(pluginResult, callbackId: command.callbackId)
+            return
+        }
+        
         commandDelegate.run(inBackground: {() -> Void in
             guard self.sessionManager != nil else {
                 print("--> Camera not started")
                 let pluginResult = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: "Camera not started")
+                self.commandDelegate.send(pluginResult, callbackId: command.callbackId)
+                return
+            }
+            
+            guard self.startCameraInProgress == false else {
+                print("--> startCamera in progress")
+                let pluginResult = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: "startCamera in progress")
                 self.commandDelegate.send(pluginResult, callbackId: command.callbackId)
                 return
             }

--- a/src/ios/CameraPreview.swift
+++ b/src/ios/CameraPreview.swift
@@ -133,38 +133,37 @@ class CameraPreview: CDVPlugin, TakePictureDelegate, FocusDelegate {
             cameraRenderController.removeFromParentViewController()
             cameraRenderController = nil
         }
+
         
-        commandDelegate.run(inBackground: {() -> Void in
-            guard self.sessionManager != nil else {
-                print("--> Camera not started")
-                let pluginResult = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: "Camera not started")
-                self.commandDelegate.send(pluginResult, callbackId: command.callbackId)
-                return
+        guard self.sessionManager != nil else {
+            print("--> Camera not started")
+            let pluginResult = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: "Camera not started")
+            self.commandDelegate.send(pluginResult, callbackId: command.callbackId)
+            return
+        }
+        
+        if let inputs = self.sessionManager.session?.inputs as? [AVCaptureInput] {
+            for input in inputs {
+                self.sessionManager.session?.removeInput(input)
             }
-            
-            if let inputs = self.sessionManager.session?.inputs as? [AVCaptureInput] {
-                for input in inputs {
-                    self.sessionManager.session?.removeInput(input)
-                }
+        }
+        
+        
+        if let outputs = self.sessionManager.session?.outputs as? [AVCaptureOutput] {
+            for output in outputs {
+                self.sessionManager.session?.removeOutput(output)
             }
-            
-            
-            if let outputs = self.sessionManager.session?.outputs as? [AVCaptureOutput] {
-                for output in outputs {
-                    self.sessionManager.session?.removeOutput(output)
-                }
-            }
-            
-            self.sessionManager.session?.stopRunning()
-            
-            if self.sessionManager != nil {
-                self.sessionManager.delegate = nil;
-                self.sessionManager = nil;
-            }
-            
-            print("--> camera stopped")
-            self.commandDelegate.send(CDVPluginResult(status: CDVCommandStatus_OK), callbackId: command.callbackId)
-        })
+        }
+        
+        self.sessionManager.session?.stopRunning()
+        
+        if self.sessionManager != nil {
+            self.sessionManager.delegate = nil;
+            self.sessionManager = nil;
+        }
+        
+        print("--> camera stopped")
+        self.commandDelegate.send(CDVPluginResult(status: CDVCommandStatus_OK), callbackId: command.callbackId)
     }
     
     @objc func hideCamera(_ command: CDVInvokedUrlCommand) {

--- a/src/ios/CameraPreview.swift
+++ b/src/ios/CameraPreview.swift
@@ -15,7 +15,7 @@ class CameraPreview: CDVPlugin, TakePictureDelegate, FocusDelegate {
     var withExifInfos = false
     var captureVideoOrientation: AVCaptureVideoOrientation?
     let dateFormatterForPhotoExif: DateFormatter = DateFormatter()
-    var startCameraInProgress = false;
+    var startCameraInProgress = false
     
     override func pluginInitialize() {
         // start as transparent


### PR DESCRIPTION
- Problem: we call multiple startCamera and stopCamera. stopCamera can finish after startCamera, session is deleted, can't take pictures.
- Solution: skip stopCamera when a startCamera in running
- \+ remove stopRunning from stopCamera because it's already called in viewWillDisappear and it can be very slow (https://stackoverflow.com/questions/17442591/stopping-avcapturesession-iphone-takes-8-seconds)
- Bug fix: stuck on placeholder
- Bug fix: crash while taking picture (https://bemyeye-team.monday.com/boards/409360103/pulses/1497134121)